### PR TITLE
Add timeout when connecting with server

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -355,7 +355,7 @@ class BasePlugin:
 
     def readMeter(self):
         try:
-            APIdata = urllib.request.urlopen("http://" + Parameters["Address"] + ":" + Parameters["Port"] + "/api/v1/data").read()
+            APIdata = urllib.request.urlopen("http://" + Parameters["Address"] + ":" + Parameters["Port"] + "/api/v1/data", timeout=self.pluginInterval/2).read()
         except:
             Domoticz.Error("Failed to communicate with Wi-Fi P1 meter at ip " + Parameters["Address"] + " with port " + Parameters["Port"])
             return False


### PR DESCRIPTION
I noticed that the thread used to communicate with the watermeter was hanging indefenitely in domoticz. Restarting the thread was not possible, or a disable/enable cycle in the hardware pane neither as it crashed the webserver because it was waiting for the blocked p1 watermeter thread.  Add a timeout to the timeout call prevents all of this..